### PR TITLE
Fix headers and footers

### DIFF
--- a/theteam-2.html
+++ b/theteam-2.html
@@ -48,16 +48,6 @@
 
     <!-- Main CSS File -->
     <link href="assets/css/main.css" rel="stylesheet" />
-
-    <!-- Bootstrap-->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
   </head>
 
   <body>
@@ -85,6 +75,7 @@
                 <li><a href="mission.html">Our Mission</a></li>
                 <li><a href="vision.html">Our Vision</a></li>
                 <li><a href="values.html">Our Values</a></li>
+                <li><a href="./theteam-2.html">Our Team</a></li>
               </ul>
             </li>
             <li><a href="projects.html">Notable Projects</a></li>

--- a/why-us.html
+++ b/why-us.html
@@ -78,6 +78,7 @@
                 <li><a href="mission.html">Our Mission</a></li>
                 <li><a href="vision.html">Our Vision</a></li>
                 <li><a href="values.html">Our Values</a></li>
+                <li><a href="./theteam-2.html">Our Team</a></li>
               </ul>
             </li>
             <li><a href="projects.html">Notable Projects</a></li>


### PR DESCRIPTION
1. "Our Team" link was missing from Why Us page and Our Team page.

2. Fixed underlined links in Our Team page navbar and footer.
